### PR TITLE
fix: strict mode compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,8 @@ function extract (options) {
   var methods
   var method
   var parse
+  var parser
+  var proto
   var name
   var index
   var i


### PR DESCRIPTION
Hi Paul,

Thank you for this plugin — it is exactly what I needed. When strict mode is enabled (I bundle my server app with rollup), this error is thrown:

> ReferenceError: parser is not defined

Due to the use of undeclared variables:
https://github.com/mrzmmr/remark-extract-frontmatter/blob/af7c38b982cfe2e1c8be394ecee240aff835112c/index.js#L24

This PR declare `proto` & `parser` and make this plugin strict mode compatible.