### PR TITLE
Fixes missing `let` in `for...of` causing issues

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ module.exports = function extract(options = {}) {
                 return
             }
 
-            for (child of children) {
+            for (let child of children) {
                 if (each(child)) {
                     return 1
                 }


### PR DESCRIPTION
```
ReferenceError: assignment to undeclared variable child
```

The absence of `let` breaks this script, causing the error above. I'm using ES Modules and Typescript, but not sure that would cause this error. Either way, I believe this syntax is not correct.