### PR TITLE
Add 'remove' option to drop parsed content from the VFile

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,14 @@ module.exports = function extract(options = {}) {
                 return
             }
 
-            for (let child of children) {
+             
+            for (let c = 0; c < children.length; c++) {
+                const child = children[c]
                 if (each(child)) {
+                    if (options.remove) {
+                        children.splice(c, 1)
+                        c--
+                    }
                     return 1
                 }
             }

--- a/index.js
+++ b/index.js
@@ -25,7 +25,6 @@ module.exports = function extract(options = {}) {
                 return
             }
 
-             
             for (let c = 0; c < children.length; c++) {
                 const child = children[c]
                 if (each(child)) {

--- a/readme.md
+++ b/readme.md
@@ -121,8 +121,7 @@ Type: `Boolean`
 
 Default: `false`
 
-Indicate if we should remove parsed frontmatter from the `VFile`. The default
-behavior is to leave the parsed content in the `VFile`
+Indicate if we should remove parsed frontmatter from the `VFile`. The default behavior is to leave the parsed content in the `VFile`
 
 ### License
 

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,16 @@ Default: `false`
 
 Specify if when an error parsing frontmatter occurs, to fail and throw error using `VFile.fail` or continue and set a warning using `VFile.message`.
 
+
+#### remove
+
+Type: `Boolean`
+
+Default: `false`
+
+Indicate if we should remove parsed frontmatter from the `VFile`. The default
+behavior is to leave the parsed content in the `VFile`
+
 ### License
 
 MIT &copy; Paul Zimmer

--- a/test.js
+++ b/test.js
@@ -91,15 +91,14 @@ test('remark-extract-frontmatter', test => {
     })
 
     test.test('Should remove frontmatter nodes when `options.remove` passed', test => {
-      const file = processor()
-        .use(extract, { yaml, remove: true })
-        .processSync(okYamlMd)
-      
-      test.ok(file.data)
-      test.ok(file.data.test === 'ok')
-      test.ok(file.toString() === '# Header\n')
-
-      test.end()
+        const file = processor()
+            .use(extract, { yaml, remove: true })
+            .processSync(okYamlMd)
+        
+        test.ok(file.data)
+        test.ok(file.data.test === 'ok')
+        test.ok(file.toString() === '# Header\n')
+        test.end()
     })
 
     test.end()

--- a/test.js
+++ b/test.js
@@ -7,13 +7,12 @@ const extract = require('.')
 
 const okYaml = `---\ntest: ok\n---\n`
 const okToml = `+++\ntest = "ok"\n+++\n`
+const okYamlMd = `---\ntest: ok\n---\n# Header`
 const badToml = `+++\ntest: ok\n+++\n`
 
 test('remark-extract-frontmatter', test => {
     const processor = remark()
         .use(frontmatter, ['yaml', 'toml'])
-
-    let file
 
     test.test('Does nothing when given nothing', test => {
         const file = processor()
@@ -81,7 +80,7 @@ test('remark-extract-frontmatter', test => {
         test.end()
     })
 
-    test.test('Should throw with `options.thros` passed and a parse error', test => {
+    test.test('Should throw with `options.throws` passed and a parse error', test => {
         test.throws(() => {
             processor()
                 .use(extract, { toml, throws: true })
@@ -89,6 +88,18 @@ test('remark-extract-frontmatter', test => {
         })
 
         test.end()
+    })
+
+    test.test('Should remove frontmatter nodes when `options.remove` passed', test => {
+      const file = processor()
+        .use(extract, { yaml, remove: true })
+        .processSync(okYamlMd)
+      
+      test.ok(file.data)
+      test.ok(file.data.test === 'ok')
+      test.ok(file.toString() === '# Header\n')
+
+      test.end()
     })
 
     test.end()

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -32,6 +32,12 @@ declare namespace remarkExtractFrontmatter {
      * `VFile.fail` or continue and set a warning using `VFile.message`
      */
     throws?: boolean;
+    
+    /**
+     * Indicate if we should remove parsed frontmatter from the `VFile`. The 
+     * default behavior is to leave this content in the `VFile`
+     */
+    remove?: boolean;
   }
 }
 


### PR DESCRIPTION
Removing the parsed content from the `VFile` tree seems like a common use case. This pull request adds that feature.